### PR TITLE
Same default options for both `show()` and `secureShow()`

### DIFF
--- a/src/JD/Cloudder/CloudinaryWrapper.php
+++ b/src/JD/Cloudder/CloudinaryWrapper.php
@@ -184,7 +184,12 @@ class CloudinaryWrapper
      */
     public function secureShow($publicId, $options = array())
     {
+        $defaults = $this->config->get('cloudder.scaling');
+        
+        $options = array_merge($defaults, $options);
+        
         $options = array_merge(['secure' => true], $options);
+        
         return $this->getCloudinary()->cloudinary_url($publicId, $options);
     }
 

--- a/tests/CloudinaryWrapperTest.php
+++ b/tests/CloudinaryWrapperTest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace JD\Cloudder\Test;
 
@@ -90,6 +90,7 @@ class CloudinaryWrapperTest extends \PHPUnit_Framework_TestCase
     {
         // given
         $filename = 'filename';
+        $this->config->shouldReceive('get')->with('cloudder.scaling')->once()->andReturn(array());
         $this->cloudinary->shouldReceive('cloudinary_url')->once()->with($filename, ['secure' => true]);
 
         // when


### PR DESCRIPTION
Default options from config file should be applied for `secureShow()` as well.

Not sure why it wasn't the case already.
