### PR TITLE
Adding PublicIds Parameter for the CloudinaryWrapper->resourcesByIds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
                 "JD\\Cloudder\\CloudderServiceProvider"
             ],
             "aliases": {
-                "Cloudder": "JD\\Cloudder\\Facades"
+                "Cloudder": "JD\\Cloudder\\Facades\\Cloudder"
             }
         }
     }

--- a/src/JD/Cloudder/CloudinaryWrapper.php
+++ b/src/JD/Cloudder/CloudinaryWrapper.php
@@ -463,13 +463,13 @@ class CloudinaryWrapper
     /**
      * Show Resources by id
      *
-     * @param  string $public_ids
-     * @param  array  $options
+     * @param  array $publicIds
+     * @param  array $options
      * @return array
      */
-    public function resourcesByIds($public_ids, $options = array())
+    public function resourcesByIds($publicIds, $options = array())
     {
-        return $this->getApi()->resources_by_ids($public_ids, $options);
+        return $this->getApi()->resources_by_ids($publicIds, $options);
     }
 
     /**

--- a/src/JD/Cloudder/CloudinaryWrapper.php
+++ b/src/JD/Cloudder/CloudinaryWrapper.php
@@ -463,12 +463,13 @@ class CloudinaryWrapper
     /**
      * Show Resources by id
      *
+     * @param  string $public_ids
      * @param  array  $options
      * @return array
      */
-    public function resourcesByIds($options = array())
+    public function resourcesByIds($public_ids, $options = array())
     {
-        return $this->getApi()->resources_by_ids($options);
+        return $this->getApi()->resources_by_ids($public_ids, $options);
     }
 
     /**

--- a/tests/CloudinaryWrapperTest.php
+++ b/tests/CloudinaryWrapperTest.php
@@ -366,11 +366,13 @@ class CloudinaryWrapperTest extends \PHPUnit_Framework_TestCase
     {
         $pids = ['pid1', 'pid2'];
 
+        $options = ['test', 'test1'];
+
         // given
-        $this->api->shouldReceive('resources_by_ids')->once()->with($pids);
+        $this->api->shouldReceive('resources_by_ids')->once()->with($pids, $options);
 
         // when
-        $this->cloudinary_wrapper->resourcesByIds($pids);
+        $this->cloudinary_wrapper->resourcesByIds($pids, $options);
     }
 
     /** @test */


### PR DESCRIPTION
Hello,

Looks like the publicIds parameter was missing from that function. I also adjusted the unit tests to account for the change. I'm not sure if this was expected, but after looking through the Cloudinary php sdk, it looks like that parameter is needed. We will need it for our purposes as well.

Thanks.