### PR TITLE
Change cloudinary_php version check from >=1.1 to ^1.1 (to stay in vers…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "cloudinary/cloudinary_php": ">=1.1"
+        "cloudinary/cloudinary_php": "^1.1"
     },
     "require-dev": {
         "laravel/framework": ">=5.0",


### PR DESCRIPTION
Changed >=1.1 to ^1.1for cloudinary_php. Otherwise, it will say "Class Cloudinary not Found".